### PR TITLE
Add libsetunbuf LD_PRELOAD-able helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ APPLETS   = dlog drlog dslog
 
 O = deps/cflag/cflag.o deps/clog/clog.o deps/dbuf/dbuf.o \
 	conf.o task.o multicall.o util.o
-D = $(O:.o=.d) dmon.d nofork.d $(APPLETS:=.d)
+D = $(O:.o=.d) dmon.d nofork.d setunbuf.d $(APPLETS:=.d)
 
 all: all-multicall-$(MULTICALL)
 
@@ -21,6 +21,9 @@ all-multicall-0:
 programs: dmon $(APPLETS)
 
 .PHONY: all-multicall-0 all-multicall-1 programs
+
+.c.o: CFLAGS := $(CFLAGS)
+setunbuf.o: CFLAGS := $(CFLAGS) -fPIC
 
 .c.o:
 	$(CC) -DMULTICALL=$(MULTICALL) $(CFLAGS) -MMD -MF $(@:.o=.d) -c -o $@ $<
@@ -40,7 +43,12 @@ nofork: libnofork.so
 libnofork.so: nofork.o
 	$(CC) $(LDFLAGS) -shared -o $@ nofork.o $(LDLIBS)
 
-.PHONY: nofork
+setunbuf: libsetunbuf.so
+
+libsetunbuf.so: setunbuf.o
+	$(CC) $(LDFLAGS) -shared -o $@ setunbuf.o $(LDLIBS)
+
+.PHONY: nofork setunbuf
 
 $(A:=-symlink): $A
 
@@ -58,7 +66,7 @@ man: dmon.8 dlog.8 dslog.8 drlog.8
 .SUFFIXES: .rst .8
 
 clean:
-	$(RM) dmon dlog dslog drlog libdmon.a dmon.o dlog.o dslog.o drlog.o nofork.o libnofork.so $O
+	$(RM) dmon dlog dslog drlog libdmon.a dmon.o dlog.o dslog.o drlog.o nofork.o libnofork.so setunbuf.o libsetunbuf.so $O
 
 mrproper: clean
 	$(RM) $D

--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ functions from the system libraries, in such a way that the process under
 effect will not be able of forking. This is interesting for running DMon
 with programs that have no option to instruct them not to fork.
 
+## Building libsetunbuf.so
+
+A tiny `LD_PRELOAD`-able "`libsetunbuf.so`" library can be built by using the
+`setunbuf` Make target. This library uses the `__attribute__((constructor))`
+attribute in order to call `setbuf(stdout, NULL);` which turns off the
+buffering of stdout on the process running under DMon. This is useful for
+viewing the output of your process through DLog in real time.

--- a/setunbuf.c
+++ b/setunbuf.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+static void __attribute__((constructor)) setunbuf(void)
+{
+    setbuf(stdout, NULL);
+}


### PR DESCRIPTION
Adds a tiny `LD_PRELOAD`-able "`libsetunbuf.so`" library which
turns off the buffering of stdout on the process running under DMon.
This is useful for viewing the output of your process through DLog
in real time.