### PR TITLE
Prevent logging from exiting on empty lines

### DIFF
--- a/dlog.c
+++ b/dlog.c
@@ -139,7 +139,6 @@ dlog_main (int argc, char **argv)
             }
 
             iov[n_iov++] = iov_from_buffer (&linebuf);
-            iov[n_iov++] = iov_from_literal ("\n");
 
             assert ((unsigned) n_iov <= (sizeof (iov) / sizeof (iov[0])));
 

--- a/drlog.c
+++ b/drlog.c
@@ -280,7 +280,6 @@ recreate_ts:
     }
 
     iov[n_iov++] = iov_from_buffer (&line);
-    iov[n_iov++] = iov_from_literal ("\n");
     assert ((unsigned) n_iov <= (sizeof (iov) / sizeof (iov[0])));
 
     for (;;) {

--- a/util.c
+++ b/util.c
@@ -603,7 +603,6 @@ freaduntil(int          fd,
             memmove (dbuf_data(overflow),
                      dbuf_data(overflow) + len,
                      dbuf_size(overflow));
-            dbuf_resize(buffer, dbuf_size(buffer) - 1);
             return dbuf_size(buffer);
         }
 


### PR DESCRIPTION
Before this commit, `freadline` did not distinguish between an empty
line and EOF. This would cause a printf such as

```c
printf("\nHello, World\n");
```

to cause dlog, dslog, or drlog to exit. This change attempts to
separate the EOF case and the empty line case to prevent this logic
from occurring.

Fixes #10
Fixes #12 